### PR TITLE
As part of integrating to the ibeaconlivinglab I noticed that if you 

### DIFF
--- a/lib/smartliving.js
+++ b/lib/smartliving.js
@@ -11,6 +11,8 @@ ATT.connect = connect;
 ATT.getActuatorCallback = getActuatorCallback
 ATT.registerActuatorCallback = registerActuatorCallback;
 ATT.send      = send;
+ATT.sendToDevice = sendToDevice;
+
 ATT.onMessage = function() {};
 ATT.credentials={};
 ATT.mqttStatus = false;
@@ -138,6 +140,21 @@ function send(value, assetId) {
   var time = Math.round(new Date().getTime() / 1000);
   var message   =  time + '|' + value;
   var topic     = 'client/' + ATT.credentials.clientId + '/out/asset/' + ATT.credentials.deviceId + assetId + '/state';
+
+  console.log('Publishing message - topic: ' + topic + ', payload: ' + message);
+  mqttClient.publish(topic, message, {
+    qos: 0,
+    retain: false
+  });
+}
+
+function sendToDevice(value, assetId) {
+
+  if (isUndefined(mqttClient) || isUndefined(assetId) || !ATT.mqttStatus) return;
+
+  var time = Math.round(new Date().getTime() / 1000);
+  var message   =  time + '|' + value;
+  var topic     = 'client/' + ATT.credentials.clientId + '/out/asset/' + assetId + '/state';
 
   console.log('Publishing message - topic: ' + topic + ', payload: ' + message);
   mqttClient.publish(topic, message, {


### PR DESCRIPTION
As part of integrating to the ibeaconlivinglab I noticed that if you create the asset via the web interface it has an id not related to the device id and therefore the send function , which assumed that the assets is the device + the asset id does not work.

I added a new function sendToDevice which takes the assetid as a single input string
