### PR TITLE
23 chars -> 22 chars

### DIFF
--- a/lib/allthingstalk.js
+++ b/lib/allthingstalk.js
@@ -97,7 +97,7 @@ function connect(){
 
 function connect(url, port) {
   
-  var mqttId   = ATT.credentials.deviceId.length > 23 ? ATT.credentials.deviceId.substring(0, 23) : ATT.credentials.deviceId;
+  var mqttId   = ATT.credentials.deviceId.length > 22 ? ATT.credentials.deviceId.substring(0, 22) : ATT.credentials.deviceId;
   
   //Funky requirements for RabbitMq MQTT Auth
   var brokerId = ATT.credentials.clientId + ':' + ATT.credentials.clientId;


### PR DESCRIPTION
Docs:

``` 
ClientId: A unique identifier, ideally a random string of up to 22 characters (for example the first 22 characters of the deviceId)
```

We're cropping ids to 23 chars, which can cause errors.